### PR TITLE
fix: skipping checkout default is specified

### DIFF
--- a/src/checkout-drivers/git-checkout.spec.ts
+++ b/src/checkout-drivers/git-checkout.spec.ts
@@ -55,4 +55,15 @@ describe("gitCheckout", () => {
         }),
     ).rejects.toThrow();
   });
+  it("does not throw if the branch was the default", async () => {
+    await gitCheckout({
+      tmpDir: tmpRepoDir,
+      remoteName: "origin",
+      branch: "master", // We set this in the gitDir
+    });
+
+    expect(readFileSync(join(tmpRepoDir, "README.md")).toString()).toContain(
+      "# This is the master branch",
+    );
+  });
 });

--- a/src/checkout-drivers/git-checkout.ts
+++ b/src/checkout-drivers/git-checkout.ts
@@ -9,14 +9,30 @@ export async function gitCheckout(options: {
   branch: string;
 }): Promise<boolean> {
   const { branch, remoteName, tmpDir } = options;
-  execSync(`git fetch ${remoteName} ${branch}`, {
+
+  const remoteInfo = execSync(`git remote show ${remoteName}`, {
     cwd: tmpDir,
     env: process.env,
-  });
-  execSync(`git checkout -b ${branch} --track ${remoteName}/${branch}`, {
-    cwd: tmpDir,
-    env: process.env,
-  });
+  }).toString();
+  const defaultMatch = /HEAD branch:\s*([a-zA-Z0-9_-]+)/.exec(remoteInfo);
+  if (!defaultMatch || !defaultMatch[1]) {
+    throw new Error(
+      `Could not determine default branch of cloned repo.\nAttempted to find in remote info:\n${remoteInfo} `,
+    );
+  }
+
+  const defaultBranch = defaultMatch[1];
+  // Skip this if the default branch is already pulled
+  if (defaultBranch !== branch) {
+    execSync(`git fetch ${remoteName} ${branch}`, {
+      cwd: tmpDir,
+      env: process.env,
+    });
+    execSync(`git checkout -b ${branch} --track ${remoteName}/${branch}`, {
+      cwd: tmpDir,
+      env: process.env,
+    });
+  }
 
   return true;
 }


### PR DESCRIPTION
# Summary

This fixes the fact that specifying the default branch fails because the that branch already exists when trying to check it out.  This will skip if the default branch is is specified because we assume that we cloned the default branch.

I do not want to (yet) skip checkout if the branch exists since we assume that the branch shouldn't exist at all and would rather throw an error than create non-deterministic results.